### PR TITLE
Allow install with PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "chia-rest-api"
     ],
     "require": {
-        "php": "^7.0",
+        "php": "^7.0 || ^8.0",
         "guzzlehttp/guzzle": "^7.0",
         "brooksyang/chia-utils": "^1.0"
     },


### PR DESCRIPTION
I've used chia-api and chia-utils on PHP 8 without any issues.